### PR TITLE
add publications -> locations to workById query type

### DIFF
--- a/thothlibrary/thoth-0_6_0/fixtures/QUERIES
+++ b/thothlibrary/thoth-0_6_0/fixtures/QUERIES
@@ -553,7 +553,7 @@
             "toc",
             "coverUrl",
             "coverCaption",
-            "publications { isbn publicationType __typename }",
+            "publications { isbn publicationType locations { locationId landingPage fullTextUrl locationPlatform } __typename }",
             "subjects { subjectId, subjectType, subjectCode, subjectOrdinal, __typename }",
             "contributions { fullName contributionType mainContribution contributor { contributorId orcid firstName lastName fullName } contributionId contributionOrdinal __typename }",
             "imprint { __typename publisher { publisherName publisherId __typename } }",


### PR DESCRIPTION
Include "locations" data when querying with workById. 