### PR TITLE
Add new query for books which only returns their workIds

### DIFF
--- a/thothlibrary/query.py
+++ b/thothlibrary/query.py
@@ -37,13 +37,14 @@ class ThothQuery:
         self.parameters = parameters
         self.param_str = self.prepare_parameters()
         self.fields_str = self.prepare_fields()
+        self.alias_of = self.prepare_alias_of()
         self.request = self.prepare_request()
         self.raw = raw
 
     def prepare_request(self):
         """Format the query request string"""
         values = {
-            "query_name": self.query_name,
+            "query_name": self.query_name + ": " + self.alias_of if self.alias_of else self.query_name,
             "parameters": "(" + self.param_str + ")" if self.param_str else '',
             "fields": "{" + self.fields_str + "}" if self.fields_str else ''
         }
@@ -88,4 +89,11 @@ class ThothQuery:
         if self.query_name in self.QUERIES and \
                 'fields' in self.QUERIES[self.query_name]:
             return "\n".join(self.QUERIES[self.query_name]["fields"])
+        return ''
+
+    def prepare_alias_of(self):
+        """Returns the GraphQL endpoint name of which the query name is an alias, if any."""
+        if self.query_name in self.QUERIES and \
+                'aliasOf' in self.QUERIES[self.query_name]:
+            return self.QUERIES[self.query_name]["aliasOf"]
         return ''

--- a/thothlibrary/thoth-0_9_0/endpoints.py
+++ b/thothlibrary/thoth-0_9_0/endpoints.py
@@ -825,6 +825,37 @@ class ThothClient0_9_0(ThothClient):
 
         return self._api_request("books", parameters, return_raw=raw)
 
+    def bookIds(self, limit: int = 100, offset: int = 0, search: str = "",
+                order: str = None, publishers: str = None,
+                work_status: str = None, raw: bool = False):
+        """
+        Returns books, in a minimal representation containing only workId
+        @param limit: the maximum number of results to return
+        @param order: a GraphQL order query statement
+        @param offset: the offset from which to retrieve results
+        @param publishers: a list of publishers to limit by
+        @param search: a filter string to search
+        @param work_status: the work status (e.g. ACTIVE)
+        @param raw: whether to return a python object or the raw server result
+        @return: either an object (default) or raw server response
+        """
+        if order is None:
+            order = {}
+        parameters = {
+            "offset": offset,
+            "limit": limit,
+        }
+
+        if search and not search.startswith('"'):
+            search = '"{0}"'.format(search)
+
+        self._dictionary_append(parameters, 'filter', search)
+        self._dictionary_append(parameters, 'order', order)
+        self._dictionary_append(parameters, 'publishers', publishers)
+        self._dictionary_append(parameters, 'workStatus', work_status)
+
+        return self._api_request("bookIds", parameters, return_raw=raw)
+
     def book_count(self, search: str = "", publishers: str = None,
                    work_status: str = None, raw: bool = False):
         """

--- a/thothlibrary/thoth-0_9_0/fixtures/QUERIES
+++ b/thothlibrary/thoth-0_9_0/fixtures/QUERIES
@@ -712,5 +712,20 @@
             "publishers",
             "workStatus"
         ]
+    },
+    "bookIds": {
+        "fields": [
+            "workId",
+            "__typename"
+        ],
+        "parameters": [
+            "limit",
+            "offset",
+            "filter",
+            "order",
+            "publishers",
+            "workStatus"
+        ],
+        "aliasOf": "books"
     }
 }


### PR DESCRIPTION
Suggested in review of thoth-dissemination bulk upload logic (https://github.com/thoth-pub/thoth-dissemination/pull/9#discussion_r1065608022). Reduces unnecessary data retrieval when finding lists of work IDs for upload.

Includes new logic for handling aliased queries, i.e. more than one item in `QUERIES` using the same GraphQL endpoint.