### PR TITLE
Add delete_location() method and more return fields to work_by_id(), for use by thoth-loader

### DIFF
--- a/thothlibrary/client.py
+++ b/thothlibrary/client.py
@@ -54,9 +54,9 @@ class ThothClient:
         bearer = "Bearer {}".format(auth.get_token())
         self.client.inject_token(bearer)
 
-    def mutation(self, mutation_name, data):
+    def mutation(self, mutation_name, data, nested=True):
         """Instantiate a thoth mutation and execute it"""
-        mutation = ThothMutation(mutation_name, data)
+        mutation = ThothMutation(mutation_name, data, nested)
         return mutation.run(self.client)
 
     def query(self, query_name, parameters, raw=False):
@@ -139,6 +139,10 @@ class ThothClient:
     def update_institution(self, institution):
         """Construct and trigger a mutation to update an institution object"""
         return self.mutation("updateInstitution", institution)
+
+    def delete_location(self, location):
+        """Construct and trigger a mutation to delete a location object"""
+        return self.mutation("deleteLocation", location, nested=False)
 
     @staticmethod
     def supported_versions():

--- a/thothlibrary/mutation.py
+++ b/thothlibrary/mutation.py
@@ -290,10 +290,16 @@ class ThothMutation():
                 ("countryCode", False)
             ],
             "return_value": "institutionId"
+        },
+        "deleteLocation": {
+            "fields": [
+                ("locationId", True),
+            ],
+            "return_value": "locationId"
         }
     }
 
-    def __init__(self, mutation_name, mutation_data):
+    def __init__(self, mutation_name, mutation_data, nested):
         """Returns new ThothMutation object with specified mutation data
 
         mutation_name: Must match one of the keys found in MUTATIONS.
@@ -304,9 +310,9 @@ class ThothMutation():
         self.return_value = self.MUTATIONS[mutation_name]["return_value"]
         self.mutation_data = mutation_data
         self.data_str = self.generate_values()
-        self.request = self.prepare_request()
+        self.request = self.prepare_request(nested)
 
-    def prepare_request(self):
+    def prepare_request(self, nested):
         """Format the mutation request string"""
         values = {
             "mutation_name": self.mutation_name,
@@ -314,17 +320,29 @@ class ThothMutation():
             "return_value": self.return_value
         }
 
-        payload = """
-            mutation {
-                %(mutation_name)s(
-                    data: {
-                        %(data)s
+        if nested:
+            payload = """
+                mutation {
+                    %(mutation_name)s(
+                        data: {
+                            %(data)s
+                        }
+                    ) {
+                        %(return_value)s
                     }
-                ) {
-                    %(return_value)s
                 }
-            }
-        """
+            """
+        else:
+            payload = """
+                mutation {
+                    %(mutation_name)s(
+                        %(data)s
+                    ) {
+                        %(return_value)s
+                    }
+                }
+            """
+
         return payload % values
 
     def run(self, client):

--- a/thothlibrary/thoth-0_9_0/fixtures/QUERIES
+++ b/thothlibrary/thoth-0_9_0/fixtures/QUERIES
@@ -410,10 +410,11 @@
             "pageInterval",
             "issues { issueOrdinal series { seriesName issnPrint issnDigital } }",
             "languages { languageCode }",
-            "publications { isbn publicationType locations { canonical fullTextUrl } __typename }",
-            "contributions { fullName contributionType mainContribution affiliations { affiliationId institution { institutionName institutionId ror fundings { institutionId program projectName projectShortname grantNumber jurisdiction } } } contributor { contributorId orcid firstName lastName } contributionId contributionOrdinal __typename }",
+            "publications { isbn publicationType publicationId locations { locationId canonical landingPage fullTextUrl locationPlatform } __typename }",
+            "contributions { fullName contributionType mainContribution affiliations { affiliationId affiliationOrdinal institution { institutionName institutionId ror fundings { institutionId program projectName projectShortname grantNumber jurisdiction } } } contributor { contributorId orcid firstName lastName } contributionId contributionOrdinal __typename }",
             "imprint { __typename publisher { publisherName publisherId __typename } }",
             "subjects { subjectId, subjectType, subjectCode, subjectOrdinal, __typename }",
+            "relations { relationOrdinal relationType relatedWork { doi __typename } __typename }",
             "__typename"
         ]
     },


### PR DESCRIPTION
Required for Ubiquity data import (see https://github.com/thoth-pub/thoth-loader/tree/ubiquity_uwp_lse).

Includes addition of basic support for other `delete_` mutations, i.e. ones which take a plain UUID rather than a `data` struct.