### PR TITLE
Add more return fields to work_by_id(), for use by thoth-dissemination

### DIFF
--- a/thothlibrary/thoth-0_9_0/fixtures/QUERIES
+++ b/thothlibrary/thoth-0_9_0/fixtures/QUERIES
@@ -415,6 +415,7 @@
             "imprint { __typename publisher { publisherName publisherId __typename } }",
             "subjects { subjectId, subjectType, subjectCode, subjectOrdinal, __typename }",
             "relations { relationOrdinal relationType relatedWork { doi __typename } __typename }",
+            "references { doi unstructuredCitation __typename }",
             "__typename"
         ]
     },

--- a/thothlibrary/thoth-0_9_0/fixtures/QUERIES
+++ b/thothlibrary/thoth-0_9_0/fixtures/QUERIES
@@ -411,11 +411,12 @@
             "issues { issueOrdinal series { seriesName issnPrint issnDigital } }",
             "languages { languageCode }",
             "publications { isbn publicationType publicationId locations { locationId canonical landingPage fullTextUrl locationPlatform } __typename }",
-            "contributions { fullName contributionType mainContribution affiliations { affiliationId affiliationOrdinal institution { institutionName institutionId ror fundings { institutionId program projectName projectShortname grantNumber jurisdiction } } } contributor { contributorId orcid firstName lastName } contributionId contributionOrdinal __typename }",
+            "contributions { fullName firstName lastName contributionType mainContribution affiliations { affiliationId affiliationOrdinal institution { institutionName institutionId ror fundings { institutionId program projectName projectShortname grantNumber jurisdiction } } } contributor { contributorId orcid firstName lastName } contributionId contributionOrdinal __typename }",
             "imprint { __typename publisher { publisherName publisherId __typename } }",
             "subjects { subjectId, subjectType, subjectCode, subjectOrdinal, __typename }",
             "relations { relationOrdinal relationType relatedWork { doi __typename } __typename }",
             "references { doi unstructuredCitation __typename }",
+            "fundings { grantNumber institution { institutionName institutionDoi ror __typename } __typename }",
             "__typename"
         ]
     },


### PR DESCRIPTION
Enhances support for SWORDv2 dissemination under Cambridge University Library pilot project.

Note that prior to this change, the query was retrieving `contribution` `fullName` but `contributor` `firstName` and `lastName`. The retrieval of `contributor` `firstName` and `lastName` was added under efb7f19b. It's not clear where these are being used, or why the `contributor` version is needed instead of the `contribution` version. Perhaps worth checking with OBC (?) that they're displaying the right names in the right places (I can think of a use case for doing it this way, but would be good to confirm).