### PR TITLE
Improve error handling (#35)

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,2 @@
+pycodestyle:
+  max-line-length: 120

--- a/thothlibrary/auth.py
+++ b/thothlibrary/auth.py
@@ -10,7 +10,7 @@ it under the terms of the Apache License v2.0.
 import json
 import urllib
 import requests
-from .errors import ThothError
+from .errors import AuthorizationError
 
 
 class ThothAuthenticator():  # pylint: disable=too-few-public-methods
@@ -24,9 +24,9 @@ class ThothAuthenticator():  # pylint: disable=too-few-public-methods
         try:
             response = requests.post(self.auth_endpoint, json=self.payload)
             if response.status_code == 401:
-                raise ThothError(self.auth_endpoint, 'Wrong credentials')
+                raise AuthorizationError(self.auth_endpoint, 'Wrong credentials')
             token = response.json()['token']
         except (KeyError, TypeError, ValueError, AssertionError,
                 json.decoder.JSONDecodeError, urllib.error.HTTPError):
-            raise ThothError(self.auth_endpoint, response)
+            raise AuthorizationError(self.auth_endpoint, response)
         return token

--- a/thothlibrary/auth.py
+++ b/thothlibrary/auth.py
@@ -28,5 +28,5 @@ class ThothAuthenticator():  # pylint: disable=too-few-public-methods
             token = response.json()['token']
         except (KeyError, TypeError, ValueError, AssertionError,
                 json.decoder.JSONDecodeError, urllib.error.HTTPError):
-            raise AuthorizationError(self.auth_endpoint, response)
+            raise AuthorizationError(self.auth_endpoint, response.text)
         return token

--- a/thothlibrary/errors.py
+++ b/thothlibrary/errors.py
@@ -22,3 +22,7 @@ class ResponseEmptyError(ThothError):
 
 class GraphQLError(ThothError):
     """GraphQL response contains `errors` field with specific information."""
+
+
+class AuthorizationError(ThothError):
+    """An authorization error occurred."""

--- a/thothlibrary/errors.py
+++ b/thothlibrary/errors.py
@@ -14,3 +14,11 @@ class ThothError(Exception):
         message = "GraphQL Error.\nRequest:\n{}\n\nResponse:\n{}".format(
             request, response)
         super().__init__(message)
+
+
+class ResponseEmptyError(ThothError):
+    """Empty response returned from GraphQL when content was expected."""
+
+
+class GraphQLError(ThothError):
+    """GraphQL response contains `errors` field with specific information."""

--- a/thothlibrary/mutation.py
+++ b/thothlibrary/mutation.py
@@ -361,10 +361,10 @@ class ThothMutation():
         result = ""
         try:
             result = client.execute(self.request)
-            if "errors" in result:
+            serialised = json.loads(result)
+            if "errors" in serialised:
                 raise AssertionError
-            return json.loads(result)[
-                "data"][self.mutation_name][self.return_value]
+            return serialised["data"][self.mutation_name][self.return_value]
         except (KeyError, TypeError, ValueError, AssertionError,
                 json.decoder.JSONDecodeError, urllib.error.HTTPError):
             raise ThothError(self.request, result)


### PR DESCRIPTION
Fixes #35.

Adds three new subtypes of ThothError:
- ResponseEmptyError
- GraphQLError
- AuthorizationError

Calling programs can test for these individually and proceed accordingly. In particular, a ResponseEmptyError is likely to indicate a temporary API outage, therefore a need to re-send the original request.