### PR TITLE
Add markup format option to work queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install is either via pip or cloning the repository.
 
 From pip:
 ```sh
-python3 -m pip install thothlibrary==1.1.2
+python3 -m pip install thothlibrary==1.2.0
 ```
 
 Or from the repo:
@@ -27,6 +27,23 @@ thoth = ThothClient()
 thoth.set_token("your-pat")
 print(thoth.works())
 ```
+
+Canonical titles and abstracts returned by work queries can be rendered in a
+specific markup format:
+
+```python
+work = thoth.work_by_id(
+    work_id="e0f748b2-984f-45cc-8b9e-13989c31dda4",
+    markup_format="PLAIN_TEXT",
+)
+```
+
+`markup_format` accepts the case-sensitive GraphQL enum strings `JATS_XML`,
+`PLAIN_TEXT`, `HTML`, and `MARKDOWN`. `JATS_XML` remains the default when the
+argument is omitted or set to `None`; the Python string is rendered as an
+unquoted GraphQL enum value. The option controls only the canonical work titles
+and abstracts selected by `work_by_id`, `work_by_doi`, `book_by_doi`,
+`chapter_by_doi`, `works`, `books`, and `chapters`.
 
 ### CLI GraphQL Usage
 Set `THOTH_PAT` for authenticated commands such as mutations.

--- a/thothlibrary/__init__.py
+++ b/thothlibrary/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """GraphQL client for Thoth"""
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 __author__ = "Javier Arias <javi@openbookpublishers.com>"
 __copyright__ = "Copyright (c) 2026 Thoth Open Metadata"
 __license__ = "Apache 2.0"

--- a/thothlibrary/client.py
+++ b/thothlibrary/client.py
@@ -65,9 +65,15 @@ class ThothClient:
                 if attempt == max_retries:
                     raise
 
-    def query(self, query_name, parameters, raw=False):
+    def query(self, query_name, parameters, raw=False, fields=None):
         """Instantiate a thoth query and execute"""
-        query = ThothQuery(query_name, parameters, self.QUERIES, raw=raw)
+        query = ThothQuery(
+            query_name,
+            parameters,
+            self.QUERIES,
+            raw=raw,
+            fields=fields,
+        )
         max_retries = 2
         for attempt in range(max_retries + 1):
             try:
@@ -178,15 +184,21 @@ class ThothClient:
         return [THOTH_VERSION]
 
     def _api_request(self, endpoint_name: str, parameters,
-                     return_raw: bool = False):
+                     return_raw: bool = False, fields=None):
         """
         Makes a request to the API
         @param endpoint_name: the name of the endpoint
         @param return_raw: whether to return raw data or an object (default)
         @param parameters: the parameters to pass to GraphQL
+        @param fields: optional per-request GraphQL field selection override
         @return: an object or JSON of the request
         """
-        response = self.query(endpoint_name, parameters, raw=return_raw)
+        response = self.query(
+            endpoint_name,
+            parameters,
+            raw=return_raw,
+            fields=fields,
+        )
 
         if return_raw:
             return response
@@ -315,16 +327,31 @@ for method_name, (query_name, arg_name, gql_arg_name) in V1_MODULE.SINGLE_ID_QUE
             arg_name,
             gql_arg_name,
             markup=method_name in {"title", "abstract", "biography"},
+            work_markup=method_name in V1_MODULE.WORK_QUERY_METHODS,
         ),
     )
 
 for method_name, (query_name, arg_name) in V1_MODULE.SINGLE_DOI_QUERIES.items():
-    setattr(ThothClient, method_name,
-            V1_MODULE._single_doi_method(query_name, arg_name))
+    setattr(
+        ThothClient,
+        method_name,
+        V1_MODULE._single_doi_method(
+            query_name,
+            arg_name,
+            work_markup=method_name in V1_MODULE.WORK_QUERY_METHODS,
+        ),
+    )
 
 for method_name, (query_name, mapping) in V1_MODULE.LIST_QUERIES.items():
-    setattr(ThothClient, method_name,
-            V1_MODULE._list_method(query_name, mapping))
+    setattr(
+        ThothClient,
+        method_name,
+        V1_MODULE._list_method(
+            query_name,
+            mapping,
+            work_markup=method_name in V1_MODULE.WORK_QUERY_METHODS,
+        ),
+    )
 
 for method_name, (query_name, mapping) in V1_MODULE.COUNT_QUERIES.items():
     setattr(ThothClient, method_name,

--- a/thothlibrary/query.py
+++ b/thothlibrary/query.py
@@ -25,7 +25,7 @@ class ThothQuery:
        and sanitised.
     """
 
-    def __init__(self, query_name, parameters, queries, raw=False):
+    def __init__(self, query_name, parameters, queries, raw=False, fields=None):
         """Returns new ThothQuery object
 
         mutation_name: Must match one of the keys found in MUTATIONS.
@@ -35,6 +35,7 @@ class ThothQuery:
         self.QUERIES = queries
         self.query_name = query_name
         self.parameters = parameters
+        self.fields = fields
         self.param_str = self.prepare_parameters()
         self.fields_str = self.prepare_fields()
         self.alias_of = self.prepare_alias_of()
@@ -89,6 +90,8 @@ class ThothQuery:
 
     def prepare_fields(self):
         """Returns a string with all query fields."""
+        if self.fields is not None:
+            return "\n".join(self.fields)
         if self.query_name in self.QUERIES and \
                 'fields' in self.QUERIES[self.query_name]:
             return "\n".join(self.QUERIES[self.query_name]["fields"])

--- a/thothlibrary/thoth-1_0_0/endpoints.py
+++ b/thothlibrary/thoth-1_0_0/endpoints.py
@@ -4,7 +4,18 @@ This program is free software; you may redistribute and/or modify
 it under the terms of the Apache License v2.0.
 """
 
-from .queries import QUERIES
+from .queries import QUERIES, render_work_fields
+
+
+WORK_QUERY_METHODS = frozenset({
+    "work_by_id",
+    "work_by_doi",
+    "book_by_doi",
+    "chapter_by_doi",
+    "works",
+    "books",
+    "chapters",
+})
 
 
 SINGLE_ID_QUERIES = {
@@ -302,15 +313,24 @@ class ThothClient1_0_0:
         return parameters
 
     def _single_id_request(self, query_name, gql_name, value, raw=False,
-                           **extra_parameters):
+                           fields=None, **extra_parameters):
         parameters = {gql_name: self._quote(value)}
         for key, extra_value in extra_parameters.items():
             self._dictionary_append(parameters, key, extra_value)
-        return self._api_request(query_name, parameters, return_raw=raw)
+        return self._api_request(
+            query_name,
+            parameters,
+            return_raw=raw,
+            fields=fields,
+        )
 
-    def _single_doi_request(self, query_name, doi, raw=False):
-        return self._api_request(query_name, {"doi": self._quote(doi)},
-                                 return_raw=raw)
+    def _single_doi_request(self, query_name, doi, raw=False, fields=None):
+        return self._api_request(
+            query_name,
+            {"doi": self._quote(doi)},
+            return_raw=raw,
+            fields=fields,
+        )
 
     def bookIds(self, limit=100, offset=0, search="", order=None,
                 publishers=None, work_status=None, work_statuses=None,
@@ -343,33 +363,72 @@ class ThothClient1_0_0:
         return self._build_structure("bookIds", ids)
 
 
-def _single_id_method(query_name, arg_name, gql_arg_name, markup=False):
+def _work_fields(query_name, markup_format):
+    return render_work_fields(
+        QUERIES[query_name]["fields"],
+        markup_format=markup_format,
+    )
+
+
+def _single_id_method(query_name, arg_name, gql_arg_name, markup=False,
+                      work_markup=False):
     def _method(self, raw=False, **kwargs):
         extra_parameters = {}
         if markup and kwargs.get("markup_format"):
             extra_parameters["markupFormat"] = kwargs["markup_format"]
+        fields = None
+        if work_markup:
+            fields = _work_fields(query_name, kwargs.get("markup_format"))
         return self._single_id_request(query_name, gql_arg_name,
                                        kwargs[arg_name], raw=raw,
+                                       fields=fields,
                                        **extra_parameters)
 
+    if work_markup:
+        _method.__doc__ = (
+            "Query a work by ID. markup_format controls canonical work "
+            "titles and abstracts."
+        )
     return _method
 
 
-def _single_doi_method(query_name, arg_name):
+def _single_doi_method(query_name, arg_name, work_markup=False):
     def _method(self, raw=False, **kwargs):
-        return self._single_doi_request(query_name, kwargs[arg_name], raw=raw)
+        fields = None
+        if work_markup:
+            fields = _work_fields(query_name, kwargs.get("markup_format"))
+        return self._single_doi_request(
+            query_name,
+            kwargs[arg_name],
+            raw=raw,
+            fields=fields,
+        )
 
+    if work_markup:
+        _method.__doc__ = (
+            "Query a work by DOI. markup_format controls canonical work "
+            "titles and abstracts."
+        )
     return _method
 
 
-def _list_method(query_name, mapping):
+def _list_method(query_name, mapping, work_markup=False):
     def _method(self, raw=False, **kwargs):
+        fields = None
+        if work_markup:
+            fields = _work_fields(query_name, kwargs.get("markup_format"))
         return self._api_request(
             query_name,
             self._query_parameters(kwargs, mapping),
             return_raw=raw,
+            fields=fields,
         )
 
+    if work_markup:
+        _method.__doc__ = (
+            "Query works. markup_format controls canonical work titles "
+            "and abstracts."
+        )
     return _method
 
 
@@ -393,15 +452,31 @@ for method_name, (query_name, arg_name, gql_arg_name) in SINGLE_ID_QUERIES.items
             arg_name,
             gql_arg_name,
             markup=method_name in {"title", "abstract", "biography"},
+            work_markup=method_name in WORK_QUERY_METHODS,
         ),
     )
 
 for method_name, (query_name, arg_name) in SINGLE_DOI_QUERIES.items():
-    setattr(ThothClient1_0_0, method_name,
-            _single_doi_method(query_name, arg_name))
+    setattr(
+        ThothClient1_0_0,
+        method_name,
+        _single_doi_method(
+            query_name,
+            arg_name,
+            work_markup=method_name in WORK_QUERY_METHODS,
+        ),
+    )
 
 for method_name, (query_name, mapping) in LIST_QUERIES.items():
-    setattr(ThothClient1_0_0, method_name, _list_method(query_name, mapping))
+    setattr(
+        ThothClient1_0_0,
+        method_name,
+        _list_method(
+            query_name,
+            mapping,
+            work_markup=method_name in WORK_QUERY_METHODS,
+        ),
+    )
 
 for method_name, (query_name, mapping) in COUNT_QUERIES.items():
     setattr(ThothClient1_0_0, method_name, _count_method(query_name, mapping))

--- a/thothlibrary/thoth-1_0_0/queries.py
+++ b/thothlibrary/thoth-1_0_0/queries.py
@@ -1,17 +1,54 @@
 """GraphQL field selections for the Thoth 1.0.0 client."""
 
-CANONICAL_TITLES = (
-    "titles(order: {field: CANONICAL, direction: DESC}, markupFormat: JATS_XML)"
-    " { titleId localeCode fullTitle title subtitle canonical __typename }"
-)
-CANONICAL_ABSTRACTS = (
-    "abstracts(order: {field: CANONICAL, direction: DESC}, markupFormat: JATS_XML)"
-    " { abstractId localeCode content abstractType canonical __typename }"
-)
+DEFAULT_WORK_MARKUP_FORMAT = "JATS_XML"
+WORK_MARKUP_FORMATS = ("JATS_XML", "PLAIN_TEXT", "HTML", "MARKDOWN")
+
+
+def _canonical_titles(markup_format):
+    return (
+        "titles(order: {field: CANONICAL, direction: DESC}, markupFormat: "
+        + markup_format
+        + ") { titleId localeCode fullTitle title subtitle canonical __typename }"
+    )
+
+
+def _canonical_abstracts(markup_format):
+    return (
+        "abstracts(order: {field: CANONICAL, direction: DESC}, markupFormat: "
+        + markup_format
+        + ") { abstractId localeCode content abstractType canonical __typename }"
+    )
+
+
+CANONICAL_TITLES = _canonical_titles(DEFAULT_WORK_MARKUP_FORMAT)
+CANONICAL_ABSTRACTS = _canonical_abstracts(DEFAULT_WORK_MARKUP_FORMAT)
 CANONICAL_BIOGRAPHIES = (
     "biographies(order: {field: CANONICAL, direction: DESC}, markupFormat: JATS_XML)"
     " { biographyId localeCode content canonical __typename }"
 )
+
+
+def render_work_fields(fields, markup_format=None):
+    """Return work fields rendered for one request's canonical markup format."""
+    if markup_format is None:
+        markup_format = DEFAULT_WORK_MARKUP_FORMAT
+    if markup_format not in WORK_MARKUP_FORMATS:
+        raise ValueError(
+            "Unsupported work markup_format {0!r}; expected one of: {1}".format(
+                markup_format,
+                ", ".join(WORK_MARKUP_FORMATS),
+            )
+        )
+
+    canonical_titles = _canonical_titles(markup_format)
+    canonical_abstracts = _canonical_abstracts(markup_format)
+    return [
+        canonical_titles if field == CANONICAL_TITLES
+        else canonical_abstracts if field == CANONICAL_ABSTRACTS
+        else field
+        for field in fields
+    ]
+
 
 WORK_LINK = (
     "work { workId doi publicationDate place "

--- a/thothlibrary/thoth-1_0_0/tests/tests.py
+++ b/thothlibrary/thoth-1_0_0/tests/tests.py
@@ -5,11 +5,26 @@ it under the terms of the Apache License v2.0.
 """
 import json
 import unittest
+from copy import deepcopy
+from importlib import import_module
 
 import requests_mock
 
 from thothlibrary import ThothClient
 from thothlibrary.client import THOTH_VERSION
+
+queries = import_module("thothlibrary.thoth-1_0_0.queries")
+
+
+WORK_METHODS = (
+    ("work_by_id", {"work_id": "work-1"}),
+    ("work_by_doi", {"doi": "10.0000/example"}),
+    ("book_by_doi", {"doi": "10.0000/example"}),
+    ("chapter_by_doi", {"doi": "10.0000/example"}),
+    ("works", {"limit": 10}),
+    ("books", {"limit": 10}),
+    ("chapters", {"limit": 10}),
+)
 
 
 class Thoth100Tests(unittest.TestCase):
@@ -25,8 +40,193 @@ class Thoth100Tests(unittest.TestCase):
     def _query_text(mocker):
         return json.loads(mocker.last_request.text)["query"]
 
+    def _capture_work_query(self, method_name, method_kwargs,
+                            markup_format=None, include_format=False,
+                            client=None):
+        kwargs = dict(method_kwargs)
+        kwargs["raw"] = True
+        if include_format:
+            kwargs["markup_format"] = markup_format
+
+        with requests_mock.Mocker() as mocker:
+            mocker.post(self.graphql_endpoint, json={"data": {}})
+            getattr(client or self._client(), method_name)(**kwargs)
+            return self._query_text(mocker)
+
+    def _assert_canonical_format(self, query, markup_format):
+        lines = {line.strip() for line in query.splitlines()}
+        self.assertIn(
+            (
+                "titles(order: {field: CANONICAL, direction: DESC}, "
+                "markupFormat: "
+                + markup_format
+                + ") { titleId localeCode fullTitle title subtitle canonical "
+                "__typename }"
+            ),
+            lines,
+        )
+        self.assertIn(
+            (
+                "abstracts(order: {field: CANONICAL, direction: DESC}, "
+                "markupFormat: "
+                + markup_format
+                + ") { abstractId localeCode content abstractType canonical "
+                "__typename }"
+            ),
+            lines,
+        )
+
     def test_default_version_is_v1(self):
         self.assertEqual(THOTH_VERSION, "1.0.0")
+
+    def test_work_methods_default_canonical_markup_to_jats_xml(self):
+        for method_name, method_kwargs in WORK_METHODS:
+            with self.subTest(method=method_name):
+                query = self._capture_work_query(method_name, method_kwargs)
+                self._assert_canonical_format(query, "JATS_XML")
+
+    def test_work_methods_render_plain_text_canonical_markup(self):
+        for method_name, method_kwargs in WORK_METHODS:
+            with self.subTest(method=method_name):
+                query = self._capture_work_query(
+                    method_name,
+                    method_kwargs,
+                    markup_format="PLAIN_TEXT",
+                    include_format=True,
+                )
+                self._assert_canonical_format(query, "PLAIN_TEXT")
+                root_lines = [
+                    line.strip()
+                    for line in query.splitlines()
+                    if line.strip().startswith((
+                        "work(",
+                        "workByDoi(",
+                        "bookByDoi(",
+                        "chapterByDoi(",
+                        "works(",
+                        "books(",
+                        "chapters(",
+                    ))
+                ]
+                self.assertEqual(len(root_lines), 1)
+                self.assertNotIn("markupFormat", root_lines[0])
+
+    def test_work_methods_treat_none_as_default_markup(self):
+        for method_name, method_kwargs in WORK_METHODS:
+            with self.subTest(method=method_name):
+                query = self._capture_work_query(
+                    method_name,
+                    method_kwargs,
+                    markup_format=None,
+                    include_format=True,
+                )
+                self._assert_canonical_format(query, "JATS_XML")
+
+    def test_work_markup_html_and_markdown_are_unquoted_enums(self):
+        for markup_format in ("HTML", "MARKDOWN"):
+            with self.subTest(markup_format=markup_format):
+                query = self._capture_work_query(
+                    "work_by_id",
+                    {"work_id": "work-1"},
+                    markup_format=markup_format,
+                    include_format=True,
+                )
+                self._assert_canonical_format(query, markup_format)
+                self.assertNotIn(
+                    'markupFormat: "{0}"'.format(markup_format),
+                    query,
+                )
+
+    def test_work_markup_only_changes_top_level_titles_and_abstracts(self):
+        query = self._capture_work_query(
+            "work_by_id",
+            {"work_id": "work-1"},
+            markup_format="PLAIN_TEXT",
+            include_format=True,
+        )
+
+        self._assert_canonical_format(query, "PLAIN_TEXT")
+        self.assertIn(queries.CANONICAL_BIOGRAPHIES, query)
+        self.assertIn(
+            "relatedWork { workId doi " + queries.CANONICAL_TITLES,
+            query,
+        )
+        self.assertIn(
+            "title(markupFormat: JATS_XML) "
+            "description(markupFormat: JATS_XML)",
+            query,
+        )
+        self.assertIn(
+            "awards { awardId title(markupFormat: JATS_XML) "
+            "prizeStatement(markupFormat: JATS_XML)",
+            query,
+        )
+        self.assertIn(
+            "endorsements { endorsementId authorName "
+            "text(markupFormat: JATS_XML)",
+            query,
+        )
+        self.assertIn(
+            "bookReviews { bookReviewId title(markupFormat: JATS_XML) "
+            "text(markupFormat: JATS_XML)",
+            query,
+        )
+
+    def test_invalid_work_markup_is_rejected_before_http_request(self):
+        invalid_values = (
+            "XML",
+            "",
+            'PLAIN_TEXT) { workId } mutation { deleteWork',
+        )
+        for method_name, method_kwargs in WORK_METHODS:
+            for markup_format in invalid_values:
+                with self.subTest(
+                    method=method_name,
+                    markup_format=markup_format,
+                ):
+                    kwargs = dict(method_kwargs)
+                    kwargs["markup_format"] = markup_format
+                    with requests_mock.Mocker() as mocker:
+                        with self.assertRaisesRegex(
+                            ValueError,
+                            "Unsupported work markup_format",
+                        ):
+                            getattr(self._client(), method_name)(**kwargs)
+                        self.assertEqual(mocker.call_count, 0)
+
+    def test_work_markup_does_not_leak_between_requests_or_clients(self):
+        original_queries = deepcopy(ThothClient.QUERIES)
+        first_client = self._client()
+        second_client = self._client()
+
+        plain_query = self._capture_work_query(
+            "work_by_id",
+            {"work_id": "work-1"},
+            markup_format="PLAIN_TEXT",
+            include_format=True,
+            client=first_client,
+        )
+        default_query = self._capture_work_query(
+            "work_by_id",
+            {"work_id": "work-2"},
+            client=first_client,
+        )
+        html_query = self._capture_work_query(
+            "work_by_id",
+            {"work_id": "work-3"},
+            markup_format="HTML",
+            include_format=True,
+            client=second_client,
+        )
+
+        self._assert_canonical_format(plain_query, "PLAIN_TEXT")
+        self._assert_canonical_format(default_query, "JATS_XML")
+        self._assert_canonical_format(html_query, "HTML")
+        self.assertEqual(ThothClient.QUERIES, original_queries)
+        self.assertIs(
+            ThothClient.QUERIES["work"]["fields"],
+            queries.WORK_FULL_FIELDS,
+        )
 
     def test_work_query_uses_multilingual_fields(self):
         payload = {
@@ -74,11 +274,13 @@ class Thoth100Tests(unittest.TestCase):
 
         with requests_mock.Mocker() as mocker:
             mocker.post(self.graphql_endpoint, json=payload)
-            result = self._client().work_by_id(work_id="work-1")
+            result = self._client().work_by_id(
+                work_id="work-1",
+                markup_format="PLAIN_TEXT",
+            )
             query = self._query_text(mocker)
 
-        self.assertIn("titles(order:", query)
-        self.assertIn("abstracts(order:", query)
+        self._assert_canonical_format(query, "PLAIN_TEXT")
         self.assertNotIn("\n                shortAbstract", query)
         self.assertNotIn("\n                longAbstract", query)
         self.assertNotIn("\n                biography", query)


### PR DESCRIPTION
## Summary

- add optional `markup_format` keyword support to `work_by_id`, `work_by_doi`, `book_by_doi`, `chapter_by_doi`, `works`, `books`, and `chapters`
- support the case-sensitive GraphQL enum values `JATS_XML`, `PLAIN_TEXT`, `HTML`, and `MARKDOWN`
- preserve `JATS_XML` as the default when the argument is omitted or `None`
- reject unsupported and injection-like values with `ValueError` before any HTTP request
- prepare package version `1.2.0` and document the public API

## Design

Work-query markup formatting belongs to the nested canonical `titles(...)` and `abstracts(...)` selections, not to the root `work`/`works` field. The generated endpoint helpers therefore consume `markup_format` as a field-rendering option and pass a fresh per-request field list through the query layer.

Rendering replaces only field entries exactly matching the canonical top-level title and abstract selections. Biographies, related-work titles, additional resources, awards, endorsements, book reviews, and other rich-text fields keep their existing `JATS_XML` selections.

No static query definition or shared field list is mutated, so sequential requests, multiple clients, concurrent calls, and tests in any order retain independent formatting.

## Verification

- `python3 -m unittest thothlibrary.tests.test_queries thothlibrary.tests.test_rest thothlibrary.thoth-1_0_0.tests.tests` — 28 tests passed
- `python3 -m compileall -q thothlibrary` — passed
- `git diff --check` — passed
- `python3 setup.py --version` — `1.2.0`

Focused coverage proves the default and `PLAIN_TEXT` rendering for all seven methods, unquoted `HTML`/`MARKDOWN`, restricted transformation, pre-request validation, raw and structured responses, and no state leakage.

## Live read-only verification

A credential-free check against `https://api.thoth.pub` used work `e0f748b2-984f-45cc-8b9e-13989c31dda4` with `raw=True`. Both explicit `JATS_XML` and `PLAIN_TEXT` calls succeeded. Three non-empty canonical title/abstract values were inspected: the JATS response retained tags, while the plain-text response contained visible text without JATS tags. No mutation was performed.

## Release preparation

This backward-compatible public API addition prepares version `1.2.0`. GitHub was checked before the bump: no `v1.2.0` tag, release-preparation branch, or issue/PR mentioning `1.2.0` existed. This PR does not create a release or publish to PyPI.